### PR TITLE
Migrated from FamilySearch Elements and renamed the behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "oak-artifact-category-behavior",
+  "name": "fs-artifact-category-behavior",
   "version": "0.0.1",
-  "main": "oak-artifact-category-behavior.html"
+  "main": "fs-artifact-category-behavior.html"
 }

--- a/fs-artifact-category-behavior.html
+++ b/fs-artifact-category-behavior.html
@@ -1,5 +1,5 @@
 <script>
-  window.OakArtifactCategoryBehavior = {
+  window.FsArtifactCategoryBehavior = {
     _getArtifactType: function(artifact) {
       if (!artifact) {
         return null;


### PR DESCRIPTION
The behavior was renamed from `oak-artifact-category-behavior` to `fs-artifact-category-behavior`.